### PR TITLE
ublox integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ proptest = { version = "1.2.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 messages-proc-macros-lib = { path = "messages-proc-macros-lib" }
 chrono = {version = "0.4.0", features = ["serde"], default-features = false}
+ublox = "0.4.5"
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/src/gps.rs
+++ b/src/gps.rs
@@ -1,0 +1,68 @@
+use messages_proc_macros_lib::common_derives;
+
+// integrate ublox with the messaging library
+#[common_derives]
+pub struct NavPosLlh {
+    pub height_msl: f64,
+    pub longitude: f64,
+    pub latitude: f64,
+}
+
+impl<'a> From<ublox::NavPosLlhRef<'a>> for NavPosLlh {
+    fn from(nav_pos_llh: ublox::NavPosLlhRef<'a>) -> Self {
+        NavPosLlh {
+            height_msl: nav_pos_llh.height_msl(),
+            longitude: nav_pos_llh.lat_degrees(),
+            latitude: nav_pos_llh.lon_degrees(),
+        }
+    }
+}
+
+#[common_derives]
+pub struct NavTimeUTC {
+    /// Nanoseconds of second, range -1e9 .. 1e9
+    pub nanos: i32,
+    /// Year, range 1999..2099
+    pub year: u16,
+    /// Month, range 1..12
+    pub month: u8,
+    /// Day of Month, range 1..31
+    pub day: u8,
+    /// Hour of Day, range 0..23
+    pub hour: u8,
+    /// Minute of Hour, range 0..59
+    pub min: u8,
+    /// Seconds of Minute, range 0..59
+    pub sec: u8,
+}
+
+impl<'a> From<ublox::NavTimeUTCRef<'a>> for NavTimeUTC {
+    fn from(nav_time_utc: ublox::NavTimeUTCRef<'a>) -> Self {
+        NavTimeUTC {
+            nanos: nav_time_utc.nanos(),
+            year: nav_time_utc.year(),
+            month: nav_time_utc.month(),
+            day: nav_time_utc.day(),
+            hour: nav_time_utc.hour(),
+            min: nav_time_utc.min(),
+            sec: nav_time_utc.sec(),
+        }
+    }
+}
+
+#[common_derives]
+pub enum Nav {
+    NavPosLlh(NavPosLlh),
+    NavTimeUTC(NavTimeUTC),
+    Other,
+}
+
+impl<'a> From<ublox::PacketRef<'a>> for Nav {
+    fn from(packet_ref: ublox::PacketRef<'a>) -> Self {
+        match packet_ref {
+            ublox::PacketRef::NavPosLlh(nav_pos_llh) => Nav::NavPosLlh(nav_pos_llh.into()),
+            ublox::PacketRef::NavTimeUTC(nav_time_utc) => Nav::NavTimeUTC(nav_time_utc.into()),
+            _ => Nav::Other,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod node;
 pub mod sensor;
 pub mod sensor_status;
 pub mod state;
+mod gps;
 
 pub const MAX_SIZE: usize = 64;
 

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -1,6 +1,6 @@
-use crate::sensor_status::{
+use crate::{gps::Nav, sensor_status::{
     AirStatus, EkfStatus, GpsPositionStatus, GpsVelStatus, ImuStatus, UtcTimeStatus,
-};
+}};
 use derive_more::From;
 use messages_proc_macros_lib::common_derives;
 
@@ -22,7 +22,7 @@ pub enum SensorData {
     EkfNavAcc(EkfNavAcc),
     Imu1(Imu1),
     Imu2(Imu2),
-    NavPosLlh(NavPosLlh),
+    Nav(Nav),
     GpsVel(GpsVel),
     GpsVelAcc(GpsVelAcc),
     GpsPos1(GpsPos1),
@@ -30,13 +30,6 @@ pub enum SensorData {
     GpsPosAcc(GpsPosAcc),
     ResetReason(ResetReason),
     RecoverySensing(RecoverySensing),
-}
-
-#[common_derives]
-pub struct NavPosLlh {
-    pub height_msl: f64,
-    pub longitude: f64,
-    pub latitude: f64,
 }
 
 /* Replace with new health monitor */


### PR DESCRIPTION
PR for this task:
https://planner.cloud.microsoft/uottawa.onmicrosoft.com/EN-US/Home/Planner/#/plantaskboard?groupId=898064ce-113c-4fa5-b321-07b7f9263df7&planId=tr5ZOiZX2ECXaJDMdQA06GUAFUAV&taskId=i-cSImPMekC0mqwUSEEP-GUALoLF

The problem with passing the objects directly from ublox's PacketRef is that they don't implement the traits we need for messaging and deriving them is not possible.

My solution is to create a mapping from PacketRef to a Nav object using the From trait.