### PR TITLE
Consolidate state structure to an enum. Move message decleration of r…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 messages-proc-macros-lib = { path = "messages-proc-macros-lib" }
 chrono = { git = "https://github.com/uorocketry/chrono", features = ["serde"], default-features = false }
 ublox = { git = "https://github.com/uorocketry/ublox", features = ["serde"], default-features = false }
-stm32h7xx-hal = { path = "/home/bonjour/Rocketry/stm32h7xx-hal", features = ["defmt", "rt", "stm32h735", "can", "rtc"] }
+stm32h7xx-hal = { git = "https://github.com/uorocketry/stm32h7xx-hal", features = ["defmt", "rt", "stm32h735", "can", "rtc"] }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 messages-proc-macros-lib = { path = "messages-proc-macros-lib" }
 chrono = { git = "https://github.com/uorocketry/chrono", features = ["serde"], default-features = false }
 ublox = { git = "https://github.com/uorocketry/ublox", features = ["serde"], default-features = false }
+stm32h7xx-hal = { path = "/home/bonjour/Rocketry/stm32h7xx-hal", features = ["defmt", "rt", "stm32h735", "can", "rtc"] }
 
 [dev-dependencies]
 proptest = "1.2.0"
@@ -28,4 +29,4 @@ postcard = { version = "1.0.4", features = ["alloc"] }
 
 [features]
 default = ["mavlink/embedded-hal-02", "mavlink/uorocketry"]
-std = ["chrono/std", "chrono/arbitrary", "mavlink/std", "mavlink/tcp", "mavlink/udp", "mavlink/direct-serial", "mavlink/serde", "dep:proptest", "dep:proptest-derive"]
+std = ["stm32h7xx-hal/arbitrary", "chrono/std", "chrono/arbitrary", "mavlink/std", "mavlink/tcp", "mavlink/udp", "mavlink/direct-serial", "mavlink/serde", "dep:proptest", "dep:proptest-derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ proptest-derive = { version = "0.3.0", optional = true }
 messages-proc-macros-lib = { path = "messages-proc-macros-lib" }
 chrono = { git = "https://github.com/uorocketry/chrono", features = ["serde"], default-features = false }
 ublox = { git = "https://github.com/uorocketry/ublox", features = ["serde"], default-features = false }
-stm32h7xx-hal = { git = "https://github.com/uorocketry/stm32h7xx-hal", features = ["defmt", "rt", "stm32h735", "can", "rtc"] }
+# The actual version imported does not matter as reset reason is not behind or affected by any feature flags. 
+stm32h7xx-hal = { git = "https://github.com/uorocketry/stm32h7xx-hal", features = ["defmt", "stm32h735"] }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub struct CanMessage {
 #[common_derives]
 #[derive(From)]
 pub enum Common {
-    ResetReason(sensor::ResetReason),
+    ResetReason(stm32h7xx_hal::rcc::ResetReason),
     Command(command::Command), 
     Log(Log),
 }

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -131,39 +131,6 @@ pub enum SbgData {
     GpsPos(GpsPos),
 }
 
-/* Replace with new health monitor */
-
-#[common_derives]
-pub enum ResetReason {
-    /// The mcu went from not having power to having power and resetting
-    PowerOnReset,
-    /// The reset pin was asserted
-    PinReset,
-    /// The brownout detector triggered
-    BrownoutReset,
-    /// The software did a soft reset through the SCB peripheral
-    SystemReset,
-    /// The software did a soft reset through the RCC periperal
-    CpuReset,
-    /// The window watchdog triggered
-    WindowWatchdogReset,
-    /// The independent watchdog triggered
-    IndependentWatchdogReset,
-    /// Either of the two watchdogs triggered (but we don't know which one)
-    GenericWatchdogReset,
-    /// The DStandby mode was exited
-    D1ExitsDStandbyMode,
-    /// The DStandby mode was exited
-    D2ExitsDStandbyMode,
-    /// A state has been entered erroneously
-    D1EntersDStandbyErroneouslyOrCpuEntersCStopErroneously,
-    /// The reason could not be determined
-    Unknown {
-        /// The raw register value
-        rcc_rsr: u32,
-    },
-}
-
 #[common_derives]
 pub struct GpsPos {
     #[doc = "< Latitude in degrees, positive north."]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,12 +1,12 @@
 use messages_proc_macros_lib::common_derives;
 
-#[common_derives]
-pub struct State {
-    pub data: StateData,
-}
+// #[common_derives]
+// pub struct State {
+//     pub data: StateData,
+// }
 
 #[common_derives]
-pub enum StateData {
+pub enum State {
     Initializing,
     WaitForTakeoff,
     Ascent,
@@ -16,8 +16,8 @@ pub enum StateData {
     Abort,
 }
 
-impl State {
-    pub fn new(data: impl Into<StateData>) -> Self {
-        State { data: data.into() }
-    }
-}
+// impl State {
+//     pub fn new(data: impl Into<StateData>) -> Self {
+//         State { data: data.into() }
+//     }
+// }


### PR DESCRIPTION
This pull request includes several changes to the project, focusing on dependency updates, code refactoring, and structural changes. The most important changes include updating the dependencies in `Cargo.toml`, modifying the `Common` enum to use a new reset reason type, and removing the `ResetReason` enum from `sensor.rs`.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R23): Added `stm32h7xx-hal` dependency with specific features and updated the `std` feature to include `stm32h7xx-hal/arbitrary`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R23) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L31-R32)

Code refactoring:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L72-R72): Modified the `Common` enum to use `stm32h7xx_hal::rcc::ResetReason` instead of `sensor::ResetReason`.
* [`src/sensor.rs`](diffhunk://#diff-1f7948fc50bc1d4c87c165413c45a96fcb1a03feff390b39fb73da822212f452L134-L166): Removed the `ResetReason` enum, which included various reset reasons and their descriptions.

Structural changes:

* [`src/state.rs`](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41L3-R9): Commented out the `State` struct and its implementation, and renamed `StateData` to `State`. [[1]](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41L3-R9) [[2]](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41L19-R23)…eset reason back to stm32h7xx-hal crate.